### PR TITLE
Include openssl binary target in OpenSSL library

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -13,7 +13,7 @@ let package = Package(
         // OpenSSL libray, can be imported by swift
         .library(
             name: "OpenSSL",
-            targets: ["OpenSSL"]
+            targets: ["OpenSSL", "openssl"]
         )
     ],
     dependencies: [],


### PR DESCRIPTION
I think not including it is what's been causing errors on a clean build when something depends on OpenSSL; the build will sometimes error with `<openssl/conf.h> not found`.